### PR TITLE
Moved the resumption commands to DSLScalaClient

### DIFF
--- a/src/main/scala/io/reactivesocket/tck/DSLTestClient.scala
+++ b/src/main/scala/io/reactivesocket/tck/DSLTestClient.scala
@@ -31,4 +31,14 @@ class DSLTestClient(writer : PrintWriter) {
 
   def getID: Int = return this.id
 
+  // resumption
+
+  def resume() : Unit = writer.write("c" + this.id + "%%" + "resume" + "\n")
+
+  def disconnect() : Unit = writer.write("c" + this.id + "%%" + "disconnect" + "\n")
+
+  def assertNoClientErrors() : Unit = writer.write("c" + this.id + "%%" + "assert%%no_client_error" + "\n")
+
+  def assertClientError() : Unit = writer.write("c" + this.id + "%%" + "assert%%client_error" + "\n")
+
 }

--- a/src/main/scala/io/reactivesocket/tck/DSLTestSubscriber.scala
+++ b/src/main/scala/io/reactivesocket/tck/DSLTestSubscriber.scala
@@ -88,12 +88,6 @@ class DSLTestSubscriber(writer : PrintWriter, initData: String, initMeta: String
 
   def take(n: Long) : Unit = writer.write("c" + clientID + "%%" + "take%%" + n + "%%" + this.id + "\n")
 
-  // resumption
-
-  def resume() : Unit = writer.write("resume%%" + this.id + "\n")
-
-  def disconnect() : Unit = writer.write("disconnect%%" + this.id + "\n")
-
   // internal functions
 
   private def printList(lst: List[(String, String)]) : String = lst.map(a => a._1 + "," + a._2).mkString("&&")

--- a/src/main/scala/io/reactivesocket/tck/ResumptionTests.scala
+++ b/src/main/scala/io/reactivesocket/tck/ResumptionTests.scala
@@ -22,13 +22,14 @@ object resumptionclienttest extends RequesterDSL {
   // example for testing stream
   @Test
   def streamResumptionTest1() : Unit = {
-    val s1 = requestStream("a", "b")
+    val c1 = client()
+    val s1 = requestStream("a", "b", Some(c1))
     s1 request 3
     s1 awaitAtLeast(3)
     s1 assertReceived(List(("a", "b"), ("c", "d"), ("e", "f")))
-    s1 disconnect()
+    c1 disconnect()
     s1 request 3
-    s1 resume()
+    c1 resume()
     s1 awaitTerminal()
     s1 assertCompleted()
     s1 assertNoErrors()
@@ -37,11 +38,12 @@ object resumptionclienttest extends RequesterDSL {
 
   @Test
   def streamResumptionTest2() : Unit = {
-    val s1 = requestStream("a", "b")
+    val c1 = client()
+    val s1 = requestStream("a", "b", Some(c1))
     s1 request 3
     s1 awaitAtLeast(3)
     s1 assertReceived(List(("a", "b"), ("c", "d"), ("e", "f")))
-    s1 disconnect()
+    c1 disconnect()
     s1 request 3
     s1 awaitNoAdditionalEvents 100
     s1 assertReceivedCount 3
@@ -49,13 +51,14 @@ object resumptionclienttest extends RequesterDSL {
 
   @Test
   def streamResumptionTest3() : Unit = {
-    val s1 = requestStream("a", "b")
+    val c1 = client()
+    val s1 = requestStream("a", "b", Some(c1))
     s1 request 3
     s1 awaitAtLeast(3)
     s1 assertReceived(List(("a", "b"), ("c", "d"), ("e", "f")))
-    s1 disconnect()
+    c1 disconnect()
     s1 request 1
-    s1 resume()
+    c1 resume()
     s1 request 2
     s1 awaitTerminal()
     s1 assertReceivedCount 6
@@ -63,12 +66,13 @@ object resumptionclienttest extends RequesterDSL {
 
   @Test
   def streamResumptionTest4() : Unit = {
-    val s1 = requestStream("a", "b")
+    val c1 = client()
+    val s1 = requestStream("a", "b", Some(c1))
     s1 request 3
     s1 awaitAtLeast(3)
     s1 assertReceived(List(("a", "b"), ("c", "d"), ("e", "f")))
-    s1 disconnect()
-    s1 resume()
+    c1 disconnect()
+    c1 resume()
     s1 request 3
     s1 awaitTerminal()
     s1 assertCompleted()


### PR DESCRIPTION
-Added assert client_error and assert no_client_error
-resume and disconnect are associated with client ID (instead of subscription ID)